### PR TITLE
🐛 fix - devcontainer improvements to allow installs on corpnets

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,22 +3,18 @@
 {
 	"name": "hve-ado-scaffold",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base",
+	"image": "mcr.microsoft.com/powershell:preview-7.6-ubuntu-24.04",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {},
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/azure-cli:1": {
 			"extensions": "azure-devops"
 		},
 		"ghcr.io/devcontainers/features/dotnet:2": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers-extra/features/pre-commit:2": {},
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/devcontainers/features/powershell": {
-			"pwsh": "latest"
-		},
+		"ghcr.io/devcontainers/features/powershell:1": {},
+		"ghcr.io/devcontainers/features/python:1": {}
 	},
 	"customizations": {
 		"vscode": {
@@ -57,7 +53,8 @@
 				// "GitHub.copilot@prerelease",
 				// "GitHub.copilot-chat@prerelease"
 				"GitHub.copilot",
-				"GitHub.copilot-chat"
+				"GitHub.copilot-chat",
+				"specstory.specstory-vscode"
 			]
 		}
 	},
@@ -73,9 +70,9 @@
 		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}"
 	},
 	"onCreateCommand": {
-		"apt": "sudo apt update && sudo apt install -y shellcheck",
+		"apt": "sudo apt update && sudo apt install -y shellcheck pipx"
 	},
-	"postCreateCommand": "bash -lc 'set -eux; curl -LsSf https://astral.sh/uv/install.sh | sh; echo \"export PATH=\\\"$HOME/.local/bin:$PATH\\\"\" >> /home/vscode/.bashrc; /home/vscode/.local/bin/uv --version'",
+	"postCreateCommand": "pipx install uv",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
chore(devcontainer): update base image and install commands, allowingto install on corpnets that blocks most SSL certificates

PR Soundtrack: [Skepta - Back 2 Back](https://www.youtube.com/watch?v=3iyARht_IJ4)